### PR TITLE
tweak_highlight 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@
 5. (optional) Tweak Color Pallet
 6. (optional) Tweak Syntax Colors and Background Transparency
 7. (optional) Tweak UI
-8. (optional) Disable Plugin Highlights
-9. (optional) Setup nvim-web-devicons
+8. (optional) Tweak Highlights Manually (bold, italic, etc...)
+9. (optional) Tweak Disable Plugin Highlights
+10. (optional) Setup nvim-web-devicons
 
 ```lua 
 -- example lazy.nvim install setup
@@ -101,7 +102,7 @@ local color = lackluster.color -- blue, green, red, orange, black, lack, luster,
 -- !must called setup() before setting the colorscheme!
 lackluster.setup({
     -- You can overwrite the following syntax colors by setting them to one of...
-    --   1) a hexcode like "#a1b2c3" for a custom color
+    --   1) a hexcode like "#a1b2c3" for a custom color.
     --   2) "default" or nil will just use whatever lackluster's default is.
     tweak_syntax = {
         string = "default",
@@ -181,7 +182,39 @@ vim.cmd.colorscheme("lackluster")
 </details>
 
 <details>
-  <summary>(OPTIONAL) Disable Plugin Highlights</summary>
+  <summary>(OPTIONAL) Tweak Highlights Manually (bold, italic, etc...)</summary>
+
+```lua
+local lackluster = require("lackluster")
+
+-- !must called setup() before setting the colorscheme!
+lackluster.setup({
+    -- tweak_highlight allows you to update or overwrite the value passed into
+    -- vim.api.nvim_set_hl which allows you to have complete control over modifying all
+    -- highlights on a granular level.
+    tweak_highlight = {
+      -- modify @keyword's highlights to be bold and italic
+      ["@keyword"] = {
+        overwrite = false, -- overwrite falsey will extend/update lackluster's defaults (nil also does this)
+        bold = true,
+        italic = true,
+        -- see `:help nvim_set_hl` for all possible keys
+      },
+      -- overwrite @function to link to @keyword
+      ["@function"] = {
+        overwrite = true, -- overwrite == true will force overwrite lackluster's default highlights
+        link = "@keyword",
+      },
+    },
+})
+
+-- !must set colorscheme after calling setup()!
+vim.cmd.colorscheme("lackluster")
+```
+</details>
+
+<details>
+  <summary>(OPTIONAL) Tweak Disable Plugin Highlights</summary>
 
 > !! `setup()` **MUST** be called before setting your colorscheme !!
 

--- a/lua/lackluster/init.lua
+++ b/lua/lackluster/init.lua
@@ -95,6 +95,7 @@ local M = {
 ---@field tweak_pallet ?LacklusterConfigTweakColor
 ---@field tweak_syntax ?LacklusterConfigTweakSyntax
 ---@field tweak_background ?LacklusterConfigTweakBackground
+---@field tweak_highlight ?{[string]:vim.api.keyset.highlight}
 ---@field disable_plugin LacklusterConfigDisablePlugin
 
 --- @type LacklusterConfig | nil
@@ -138,6 +139,7 @@ local default_config = {
         keyword_return = "default",
         keyword_exception = "default",
     },
+    tweak_highlight = {},
     tweak_background = {
         -- ('default' is default) ('none' is transparent) ('#ffaaff' is a custom hexcode)
         normal = "default", -- main background
@@ -232,14 +234,14 @@ local load_variant = function(opt)
     theme.syntax = vim.tbl_extend("force", theme.syntax, theme.syntax_tweak)
 end
 
-local highlight_apply = function()
+---@param config LacklusterConfig
+local highlight_apply = function(config)
     local dedup_set = {}
     local highlight_group_list = highlight(theme, color)
 
     for _, highlight_group in ipairs(highlight_group_list) do
         local highlight_spec_list = highlight_group.highlight
-        ---@diagnostic disable-next-line: need-check-nil
-        local is_plugin_enabled = not USER_CONFIG.disable_plugin[highlight_group.plugin_name]
+        local is_plugin_enabled = not config.disable_plugin[highlight_group.plugin_name]
 
         if highlight_group.dont_skip or is_plugin_enabled then
             for _, hl_spec in ipairs(highlight_spec_list) do
@@ -255,6 +257,10 @@ local highlight_apply = function()
             end
         end
     end
+
+    if config.tweak_highlight ~= nil and (not vim.tbl_isempty(config.tweak_highlight)) then
+        tweak.highlight(config.tweak_highlight)
+    end
 end
 
 -- apply the colorscheme
@@ -266,7 +272,7 @@ M.load = function(opt)
     end
 
     load_variant(opt)
-    highlight_apply()
+    highlight_apply(USER_CONFIG)
 end
 
 return M

--- a/lua/lackluster/tweak.lua
+++ b/lua/lackluster/tweak.lua
@@ -95,4 +95,33 @@ M.ui = function(tweak_ui, theme, color)
     end
 end
 
+---update or overwrite a hl_name with an hl_value
+---@param hl_name string
+---@param hl_value vim.api.keyset.highlight
+---@param force boolean
+local function tweak_highlight_apply(hl_name, hl_value, force)
+    if force then
+        vim.api.nvim_set_hl(0, hl_name, hl_value)
+        return
+    end
+    local old_value = vim.api.nvim_get_hl(0, { name = hl_name })
+    if vim.tbl_isempty(old_value) then
+        return tweak_highlight_apply(hl_name, hl_value, true)
+    end
+    vim.api.nvim_set_hl(0, hl_name, vim.tbl_extend("force", old_value, hl_value))
+end
+
+---update or overwrite highlights
+---@param tweak_highlight {[string]:vim.api.keyset.highlight}
+M.highlight = function(tweak_highlight)
+    for hl_name, hl_value in pairs(tweak_highlight) do
+        if hl_value.overwrite then
+            hl_value.overwrite = nil
+            tweak_highlight_apply(hl_name, hl_value, true)
+        else
+            tweak_highlight_apply(hl_name, hl_value, false)
+        end
+    end
+end
+
 return M


### PR DESCRIPTION
allow users to granularly tweak highlights

Addresses issues #51 and #57 

I had initially been hesitant to support allowing complete customization to all highlights from the `setup()` func but I agreed with @vadymbiliuk's suggestion to support customizing bold and italic highlights, after playing around with several different APIs, I decided the simplest solution was to allow users to update or overwrite the value lackluster passes into `nvim_set_hl`. 

