### PR TITLE
fix optional `nvim-web-devicons` setup doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ require('nvim-web-devicons').setup({
     color_icons = false,
     override = {
         ["default_icon"] = {
+            icon = "",
             color = lackluster.color.gray4,
             name = "Default",
         }


### PR DESCRIPTION
## Checklist 
- [x] I read the [CONTRIBUTING GUIDE](https://github.com/slugbyte/lackluster.nvim/blob/main/CONTRIBUTING.md)
- [ ] I opened a CONTRIBUTING ISSUE before opening the PR

## Description

Sample `nvim-web-devicons` setup doc removes the default icon.

### Screenshots
![image](https://github.com/user-attachments/assets/74483135-c6a5-4ef1-98aa-3d565470b711)
