### PR TITLE
fix optional `nvim-web-devicons` setup doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ require('nvim-web-devicons').setup({
     color_icons = false,
     override = {
         ["default_icon"] = {
+            icon = "",
             color = lackluster.color.gray4,
             name = "Default",
         }


### PR DESCRIPTION
## Checklist 
- [x] I read the [CONTRIBUTING GUIDE](https://github.com/slugbyte/lackluster.nvim/blob/main/CONTRIBUTING.md)
- [ ] I opened a CONTRIBUTING ISSUE before opening the PR

## Description

The existing sample `nvim-web-devicons` setup doc advises to do:

![image](https://github.com/user-attachments/assets/eed9d2af-e12b-45b4-a3da-b0572b4f946c)

Since we're overriding the `default_icon` to override the colors of the icons, not putting the `default_icon.icon` removes the icon for the `default_icon`.

## Screenshots

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/74483135-c6a5-4ef1-98aa-3d565470b711) |![image](https://github.com/user-attachments/assets/0a073824-43bb-45f9-a8ee-75bcc0512349) |
