### PR TITLE
Fix missing BufferLineDuplicate(Selected/Visible) highlights for bufferline plugin

### DIFF
--- a/lua/lackluster/plugin/bufferline.lua
+++ b/lua/lackluster/plugin/bufferline.lua
@@ -27,7 +27,7 @@ return function(theme)
             spec.co("BufferLinePickSelected", color.black, color.gray9),
             spec.co("BufferLinePickVisible", color.black, color.gray9),
 
-            -- seperat
+            -- separate
             spec.co("BufferLineSeparator", bg_fill, bg_fill),
             spec.co("BufferLineOffsetSeparator", bg_fill, bg_fill),
             spec.co("BufferLineTabSeparator", bg_fill, bg_fill),
@@ -60,7 +60,7 @@ return function(theme)
             spec.co("BufferLineDiagnostic", fg_nc, bg_nc),
             spec.co("BufferLineDuplicate", color.blue, bg_nc),
 
-            -- visable
+            -- visible
             spec.co("BufferLineBufferVisible", fg_vis, bg_vis),
             spec.co("BufferLineCloseButtonVisible", fg_nc, bg_vis),
             spec.co("BufferLineIndicatorVisible", bg_vis, bg_vis),

--- a/lua/lackluster/plugin/bufferline.lua
+++ b/lua/lackluster/plugin/bufferline.lua
@@ -2,9 +2,6 @@ local spec = require("lackluster.spec")
 local color = require("lackluster.color")
 
 -- TODO: HELP: I cannot figure out how to make these appear
--- BufferLineDuplicate
--- BufferLineDuplicateSelected
--- BufferLineDuplicateVisible
 -- BufferLineGroupLabel
 
 ---@param theme LacklusterTheme
@@ -61,6 +58,7 @@ return function(theme)
             spec.co("BufferLineWarning", fg_nc, bg_nc),
             spec.co("BufferLineWarningDiagnostic", fg_nc, bg_nc),
             spec.co("BufferLineDiagnostic", fg_nc, bg_nc),
+            spec.co("BufferLineDuplicate", color.blue, bg_nc),
 
             -- visable
             spec.co("BufferLineBufferVisible", fg_vis, bg_vis),
@@ -78,6 +76,7 @@ return function(theme)
             spec.co("BufferLineWarningVisible", fg_nc, bg_nc),
             spec.co("BufferLineWarningDiagnosticVisible", fg_nc, bg_nc),
             spec.co("BufferLineDiagnosticVisible", fg_nc, bg_nc),
+            spec.co("BufferLineDuplicateVisible", color.blue, bg_vis),
 
             -- selected
             spec.co("BufferLineBufferSelected", fg_active, theme.ui.bg_tab_active),
@@ -95,6 +94,7 @@ return function(theme)
             spec.co("BufferLineWarningSelected", fg_active, bg_active),
             spec.co("BufferLineWarningDiagnosticSelected", fg_active, bg_active),
             spec.co("BufferLineDiagnosticSelected", fg_active, bg_active),
+            spec.co("BufferLineDuplicateSelected", fg_active, bg_active, { bold = true }),
         },
     }
 end


### PR DESCRIPTION
## Checklist 
- [ ] I read the [CONTRIBUTING GUIDE](https://github.com/slugbyte/lackluster.nvim/blob/main/CONTRIBUTING.md)
- [ ] I opened a CONTRIBUTING ISSUE before opening the PR

## Description
In configuration of bufferline plugin ("lua/lackluster/plugin/bufferline.lua") missing BufferLineDuplicate(Selected/Visible) highlights. This leads to incorrect display of buffers with the same names (bufferline adds parent paths when buffer names match).

Added BufferLineDuplicate(Selected/Visible) highlights into configuration of bufferline plugin ("lua/lackluster/plugin/bufferline.lua") to correct a visual flaw.

### Screenshots
![image](https://github.com/user-attachments/assets/88520665-a8bb-4dc1-a34a-60a4c226e3e8)